### PR TITLE
Update eddl_load_save

### DIFF
--- a/examples/NN/other/eddl_load_save.cpp
+++ b/examples/NN/other/eddl_load_save.cpp
@@ -60,16 +60,16 @@ int main(int argc, char **argv) {
     eddlT::div_(x_test, 255.0);
 
 
-    save(net,"model1.bin");
+    save(net,"model1.bin", "bin");
 
     // Train model
     fit(net, {x_train}, {y_train}, batch_size, epochs);
 
 
-    load(net,"model1.bin");
+    load(net,"model1.bin", "bin");
     fit(net, {x_train}, {y_train}, batch_size, epochs);
 
-    load(net,"model1.bin");
+    load(net,"model1.bin", "bin");
     fit(net, {x_train}, {y_train}, batch_size, epochs);
 
 


### PR DESCRIPTION
Updates the `eddl_load_save` example to the latest `eddl::{load,save}` signature. Without this, running the example leads to:

```
Format not implemented: *.'' (Tensor::save)
```
