### PR TITLE
Use std::function in NetLoss

### DIFF
--- a/src/apis/eddl.cpp
+++ b/src/apis/eddl.cpp
@@ -343,13 +343,13 @@ namespace eddl {
         return nullptr;
     }
 
-    loss newloss(Layer* (*f)(vector<Layer *>),vector<Layer *> in,string name)
+    loss newloss(const std::function<Layer*(vector<Layer*>)>& f, vector<Layer*> in, string name)
     {
-      return new NetLoss((*f),in,name);
+      return new NetLoss(f,in,name);
     }
-    loss newloss(Layer* (*f)(Layer *),Layer *in,string name)
+    loss newloss(const std::function<Layer*(Layer*)>& f, Layer *in, string name)
     {
-      return new NetLoss((*f),in,name);
+      return new NetLoss(f,in,name);
     }
     // ---- METRICS ----
     Metric* getMetric(string type) {

--- a/src/apis/eddl.h
+++ b/src/apis/eddl.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <thread>
 #include <pthread.h>
+#include <functional>
 
 #include "../net/net.h"
 #include "../net/netloss.h"
@@ -94,9 +95,9 @@ namespace eddl {
 // ---- LOSSES ----
     Loss* getLoss(string type);
 
-    loss newloss(Layer* (*f)(vector<Layer *>),vector<Layer *> in,string name);
-    loss newloss(Layer* (*f)(Layer *),Layer *in,string name);
 
+    loss newloss(const std::function<Layer*(vector<Layer*>)>& f, vector<Layer*> in, string name);
+    loss newloss(const std::function<Layer*(Layer*)>& f, Layer *in, string name);
 
 
 

--- a/src/net/netloss.cpp
+++ b/src/net/netloss.cpp
@@ -16,7 +16,7 @@
 #include "../layers/core/layer_core.h"
 
 
-NetLoss::NetLoss(Layer* (*f)(vector<Layer *>),vector<Layer *> in,string name)
+NetLoss::NetLoss(const std::function<Layer*(vector<Layer*>)>& f, vector<Layer*> in, string name)
 {
  this->name=name;
 
@@ -25,7 +25,7 @@ NetLoss::NetLoss(Layer* (*f)(vector<Layer *>),vector<Layer *> in,string name)
  for(int i=0;i<in.size();i++)
   ginput.push_back(new LInput(new Tensor(in[i]->output->getShape()),"graph_input"+i,DEV_CPU));
 
- fout=(*f)(ginput);
+ fout=f(ginput);
 
  graph=new Net(ginput,{fout});
 
@@ -35,7 +35,7 @@ NetLoss::NetLoss(Layer* (*f)(vector<Layer *>),vector<Layer *> in,string name)
 
 }
 
-NetLoss::NetLoss(Layer* (*f)(Layer *),Layer * in,string name)
+NetLoss::NetLoss(const std::function<Layer*(Layer*)>& f, Layer *in, string name)
 {
  this->name=name;
 
@@ -43,7 +43,7 @@ NetLoss::NetLoss(Layer* (*f)(Layer *),Layer * in,string name)
 
  ginput.push_back(new LInput(new Tensor(in->output->getShape()),"graph_input",DEV_CPU));
 
- fout=(*f)(ginput[0]);
+ fout=f(ginput[0]);
 
  graph=new Net(ginput,{fout});
 

--- a/src/net/netloss.h
+++ b/src/net/netloss.h
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
+#include <functional>
 
 
 #include "net.h"
@@ -29,8 +30,8 @@ public:
     vector <Layer *>ginput;
     Layer* fout;
 
-    NetLoss(Layer* (*f)(vector<Layer *>),vector<Layer *> in,string name);
-    NetLoss(Layer* (*f)(Layer *),Layer * in,string name);
+    NetLoss(const std::function<Layer*(vector<Layer*>)>& f, vector<Layer*> in, string name);
+    NetLoss(const std::function<Layer*(Layer*)>& f, Layer *in, string name);
     ~NetLoss();
     float compute();
 


### PR DESCRIPTION
These changes stem from a problem in the Python bindings. Pybind11 does not support function pointers as arguments, so I am currently unable to bind `newloss` from the `eddl` API. However, Pybind11 does support `std::function`. With these changes I was able to bind `newloss` and reproduce the `mnist_{gan,wgan}` examples in Python. On the C++ side the functions can be used in the same way (I have tested the C++ GAN examples and they run with no change), so there's no impact on the C++ user.

I'd like to request a change from function pointers to `std::function` across the board, to avoid more problems with the Python bindings.