### PR TITLE
Throw exceptions instead of calling exit

### DIFF
--- a/src/apis/eddl.cpp
+++ b/src/apis/eddl.cpp
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <stdexcept>
 
 #include "eddl.h"
 
@@ -372,8 +373,7 @@ namespace eddl {
             return new MMeanRelativeError();
         }
         else {
-            cout<<"Not supported metric: "<<type<<"\n";
-            exit(1);
+            throw std::invalid_argument("unsupported metric: " + type);
         }
         return nullptr;
     }
@@ -845,8 +845,7 @@ namespace eddl {
                 out.push_back(net->layers[i]);
 
         if (out.size()==0) {
-            cout<<"Forwar over net "<<net->name<<"without outputs\n";
-            exit(1);
+            throw std::runtime_error("forward over net " + net->name + " without outputs");
         }
 
 
@@ -953,28 +952,24 @@ namespace eddl {
         if ((!exist(trX)) || (!exist(trY)) || (!exist(tsX)) || (!exist(tsY))) {
             cmd = "wget https://www.dropbox.com/s/khrb3th2z6owd9t/trX.bin";
             int status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_mnist");
-                exit(1);
             }
 
             cmd = "wget https://www.dropbox.com/s/m82hmmrg46kcugp/trY.bin";
             status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_mnist");
-                exit(1);
             }
             cmd = "wget https://www.dropbox.com/s/7psutd4m4wna2d5/tsX.bin";
             status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_mnist");
-                exit(1);
             }
             cmd = "wget https://www.dropbox.com/s/q0tnbjvaenb4tjs/tsY.bin";
             status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_mnist");
-                exit(1);
             }
         }
     }
@@ -991,28 +986,24 @@ namespace eddl {
         if ((!exist(trX)) || (!exist(trY)) || (!exist(tsX)) || (!exist(tsY))) {
             cmd = "wget https://www.dropbox.com/s/wap282xox5ew02d/cifar_trX.bin";
             int status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_cifar10");
-                exit(1);
             }
 
             cmd = "wget https://www.dropbox.com/s/yxhw99cu1ktiwxq/cifar_trY.bin";
             status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_cifar10");
-                exit(1);
             }
             cmd = "wget https://www.dropbox.com/s/dh9vqxe9vt7scrp/cifar_tsX.bin";
             status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_cifar10");
-                exit(1);
             }
             cmd = "wget https://www.dropbox.com/s/gdmsve6mbu82ndp/cifar_tsY.bin";
             status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_cifar10");
-                exit(1);
             }
 
         }
@@ -1027,16 +1018,14 @@ namespace eddl {
         if ((!exist(trX)) || (!exist(trY)) ) {
             cmd = "wget https://www.dropbox.com/s/sbd8eu32adcf5oi/drive_x.npy";
             int status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_drive");
-                exit(1);
             }
 
             cmd = "wget https://www.dropbox.com/s/qp0j8oiqzf6tc1a/drive_y.npy";
             status = system(cmd.c_str());
-            if (status < 0) {
+            if (status != 0) {
                 msg("wget must be installed", "eddl.download_drive");
-                exit(1);
             }
         }
     }

--- a/src/descriptors/descriptor_reduce.cpp
+++ b/src/descriptors/descriptor_reduce.cpp
@@ -7,6 +7,7 @@
 * All rights reserved
 */
 
+#include <stdexcept>
 
 #include "descriptors.h"
 #include "../tensor/tensor_reduction.h"
@@ -43,8 +44,7 @@ ReduceDescriptor::ReduceDescriptor(Tensor *A,vector<int> axis, string mode, bool
 
   for(int i=0;i<axis.size();i++)
     if (axis[i]>=A->ndim) {
-      cout<<"axis "<<axis[i]<<"> dim="<<A->ndim<<"\n";
-      exit(1);
+      throw std::runtime_error("axis " + std::to_string(axis[i]) + " > dim=" + std::to_string(A->ndim));
     }
 
 

--- a/src/hardware/cpu/cpu_reduction.cpp
+++ b/src/hardware/cpu/cpu_reduction.cpp
@@ -7,6 +7,7 @@
 * All rights reserved
 */
 
+#include <stdexcept>
 
 #include "cpu_hw.h"
 
@@ -38,8 +39,7 @@ void cpu_reduce(Tensor *A, Tensor *B,string mode,int* map)
     delete C;
   }
   else {
-    cout<<"mode: "<<mode<<" not yet implemented\n";
-    exit(1);
+    throw std::invalid_argument("mode: " + mode + " not yet implemented");
   }
 }
 void cpu_reduce(Tensor *A, Tensor *B,string mode,MapReduceDescriptor *MD)
@@ -74,8 +74,7 @@ void cpu_reduce_op(Tensor *A, Tensor *B,string op,int* map)
       A->ptr[i]/=B->ptr[map[i]];
   }
   else {
-    cout<<"op: "<<op<<" not yet implemented\n";
-    exit(1);
+    throw std::invalid_argument("op: " + op + " not yet implemented");
   }
 }
 

--- a/src/hardware/gpu/gpu_reduction.cu
+++ b/src/hardware/gpu/gpu_reduction.cu
@@ -18,6 +18,8 @@
 #include <thrust/functional.h>
 #include <thrust/extrema.h>
 
+#include <stdexcept>
+
 #include "gpu_tensor.h"
 #include "gpu_kernels.h"
 #include "gpu_hw.h"
@@ -77,8 +79,7 @@ void gpu_reduce(Tensor *A, Tensor *B,string mode,int* map)
 
   }
   else {
-    cout<<"mode: "<<mode<<" not yet implemented\n";
-    exit(1);
+    throw std::invalid_argument("mode: " + mode + " not yet implemented");
   }
 
 
@@ -138,8 +139,7 @@ void gpu_reduce(Tensor *A, Tensor *B,string mode,MapReduceDescriptor *MD)
 
   }
   else {
-    cout<<"mode: "<<mode<<" not yet implemented\n";
-    exit(1);
+    throw std::invalid_argument("mode: " + mode + " not yet implemented");
   }
 
 }
@@ -179,8 +179,7 @@ void gpu_reduce_op(Tensor *A, Tensor *B,string op,int *map)
     check_cuda(cudaDeviceSynchronize(),"reduce_mean");
   }
   else {
-    cout<<"op: "<<op<<" not yet implemented\n";
-    exit(1);
+    throw std::invalid_argument("op: " + op + " not yet implemented");
   }
 
 
@@ -224,8 +223,7 @@ void gpu_reduce_op(Tensor *A, Tensor *B,string op,MapReduceDescriptor *MD)
     check_cuda(cudaDeviceSynchronize(),"reduce_mean");
   }
   else {
-    cout<<"op: "<<op<<" not yet implemented\n";
-    exit(1);
+    throw std::invalid_argument("op: " + op + " not yet implemented");
   }
 
 }

--- a/src/layers/core/layer_tensor.cpp
+++ b/src/layers/core/layer_tensor.cpp
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
+#include <stdexcept>
 
 #include "layer_core.h"
 #include "../merge/layer_merge.h"  // TODO: Review dependency (LADD)
@@ -45,8 +46,7 @@ LTensor::LTensor(string fname) : LinLayer("ltensor" + to_string(total_layers), D
 LTensor * LTensor::fromCSV(string fname) {
   FILE *fe = fopen(fname.c_str(), "rt");
   if (fe == nullptr) {
-      fprintf(stderr, "%s not found\n", fname.c_str());
-      exit(1);
+      throw std::runtime_error(fname + " not found");
   }
   vector<int> shape;
   int ndim,v;

--- a/src/net/compserv.cpp
+++ b/src/net/compserv.cpp
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 #include "compserv.h"
 
@@ -28,8 +29,7 @@ CompServ::CompServ(int t, const vector<int> g, const vector<int> &f,int lsb, int
     this->lsb=lsb;
 
     if (lsb<0) {
-      fprintf(stderr,"Error creating CS with lsb<0 in CompServ::CompServ");
-      exit(EXIT_FAILURE);
+      throw std::runtime_error("Error creating CS with lsb<0 in CompServ::CompServ");
     }
 
     mem_level=mem;

--- a/src/net/net_api.cpp
+++ b/src/net/net_api.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <chrono>
 #include <thread>
+#include <stdexcept>
 #include "net.h"
 #include <pthread.h>
 #include "../utils.h"
@@ -161,8 +162,7 @@ void Net::run_snets(void *(*F)(void *t))
 
     rc = pthread_create(&thr[i], nullptr, (*F), (void *) (&td[i]));
     if (rc) {
-        fprintf(stderr, "Error:unable to create thread %d", rc);
-        exit(-1);
+        throw std::runtime_error("unable to create thread " + std::to_string(rc));
     }
   }
 
@@ -170,8 +170,7 @@ void Net::run_snets(void *(*F)(void *t))
   for (int i = 0; i < comp; i++) {
     rc = pthread_join(thr[i], &status);
     if (rc) {
-        cout << "Error:unable to join," << rc << endl;
-        exit(-1);
+        throw std::runtime_error("unable to join thread " + std::to_string(rc));
     }
   }
 }

--- a/src/tensor/tensor.cpp
+++ b/src/tensor/tensor.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <stdexcept>
 
 #include "tensor.h"
 #include "../utils.h"
@@ -35,14 +36,12 @@ Tensor::Tensor(const vector<int> &shape, float *fptr, int dev){
      */
 #ifndef cGPU
     if ((dev > DEV_CPU)&&(dev<DEV_FPGA)) {
-        fprintf(stderr, "Not compiled for GPU\n");
-        exit(0);
+        throw std::runtime_error("Not compiled for GPU");
     }
 #endif
 #ifndef cFPGA
     if (dev >= DEV_FPGA) {
-        fprintf(stderr, "Not compiled for FPGA\n");
-        exit(0);
+        throw std::runtime_error("Not compiled for FPGA");
     }
 #endif
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <string>
 #include <sys/stat.h>
+#include <stdexcept>
 
 #include "system_info.h"
 #include "utils.h"
@@ -48,12 +49,11 @@
 
 
 void msg(const string& text, const string& title) {
-    std::cout << text;
+    string s(text);
     if(!title.empty()){
-        std::cout << " (" << title << ")";
+	s += " (" + title + ")";
     }
-    std::cout << endl;
-    exit(0);
+    throw std::runtime_error(s);
 }
 
 
@@ -87,8 +87,7 @@ float *get_fmem(long int size, char *str){
     // Not enough free memory
     if (error) {
         delete ptr;
-        fprintf(stderr, "Error allocating %s in %s\n", humanSize(size*sizeof(float)), str);
-        exit(EXIT_FAILURE);
+        throw std::runtime_error("Error allocating " + string(humanSize(size*sizeof(float))) + " in " + string(str));
     }
 
     return ptr;
@@ -145,8 +144,7 @@ unsigned long get_free_mem() {
 
     struct vm_statistics64 vm_stat{};
     if (host_statistics64(host_port, HOST_VM_INFO64, (host_info64_t)&vm_stat, &host_size) != KERN_SUCCESS) {
-        fprintf(stderr,"Failed to fetch vm statistics");
-        exit(EXIT_FAILURE);
+        throw std::invalid_argument("Failed to fetch vm statistics");
     }
     unsigned long mem_free = (vm_stat.free_count +vm_stat.inactive_count) * pagesize;
     //fprintf(stderr,"%s Free\n",humanSize(mem_free));


### PR DESCRIPTION
Several functions currently handle error conditions by printing a message to stdout and calling `exit`, for instance [getMetric](https://github.com/deephealthproject/eddl/blob/6a4f54a187af698a8f094918efd038ac40698c37/src/apis/eddl.cpp#L307). This prevents the library user (Python bindings included) from handling the error condition. Such functions should throw exceptions instead, to propagate the error and thus give the user a choice on what to do about it. In particular, with pybind11, C++ exceptions can be converted to Python exceptions.

This PR removes all calls to `exit` and replaces them with exception throws.