### PR TITLE
Improve message about failed example dataset download

### DIFF
--- a/src/apis/eddl.cpp
+++ b/src/apis/eddl.cpp
@@ -1111,8 +1111,11 @@ namespace eddl {
             cout<<file[i]<<" x\n";
             cmd = "wget -q --show-progress https://www.dropbox.com/s/"+link[i]+"/"+file[i];
             int status = system(cmd.c_str());
-            if (status != 0){
-                msg("wget must be installed", "eddl.download_"+name);
+            if (status < 0){
+                msg("Error executing wget.  Is it installed?", "eddl.download_"+name);
+            }
+            else if (status > 0){
+                msg("wget failed to download dataset (exit code: " + status "). See previous messages for details.", "eddl.download_"+name);
             }
           }
           else {


### PR DESCRIPTION
The original message suggests wget may not be installed even when it was executed but it returned an error because it failed to download the requested file.