### PR TITLE
Temporary fix for memory management in eddl_onnx_import.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.9.2)
-#cmake_policy(set CMP0074 NEW)
+if(POLICY CMP0074)
+	cmake_policy(SET CMP0074 NEW)
+endif()
 
 ###########################################################################
 ################################ OPTIONS ##################################

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -39,7 +39,11 @@ endforeach()
 #################################################################################
 macro(CONF_PACKAGE package_name build_type only_substitution)
     configure_file(${package_name}.CMakeLists.txt.in ${EP_BASE_DIR}/${package_name}-download/CMakeLists.txt ${only_substitution})
-    execute_process(COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR} . -D CMAKE_BUILD_TYPE=${build_type}
+    set(conf_command ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . -DCMAKE_BUILD_TYPE=${build_type})
+    if(CMAKE_GENERATOR_PLATFORM)
+        list(APPEND conf_command -A ${CMAKE_GENERATOR_PLATFORM})
+    endif()
+    execute_process(COMMAND ${conf_command}
             RESULT_VARIABLE result
             WORKING_DIRECTORY ${EP_BASE_DIR}/${package_name}-download)
     if(result)


### PR DESCRIPTION
New std::vectors have ben substituted with pointers to already existing ones, and their data has been copied to a standard dynamic float[] which get deleted by the Tensor destructor.

In this way ONNX tests also work under Windows. Nothing crashes in Linux tests, nor in our machines.