### PR TITLE
Fix onnx import for upsampling layers

### DIFF
--- a/src/serialization/onnx/eddl_onnx_import.cpp
+++ b/src/serialization/onnx/eddl_onnx_import.cpp
@@ -924,8 +924,6 @@ using namespace std;
 						size_vector.push_back((int)height_scale);
 						size_vector.push_back((int)width_scale);
 						actual_layer = new LUpSampling(parent, size_vector, interpolation_mode, name, dev, mem);
-						delete scales;
-
 					}
 					break;
 


### PR DESCRIPTION
This PR fix the import of onnx files with Upsampling layers.
```cpp
vector<float>* scales = &(map_init_values[scales_name]);
```
`scales` should not be deleted because `map_init_values` object is deleted at the end of the function automatically.